### PR TITLE
fix-shadow-artifacts-glx

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -457,7 +457,9 @@ void paint_all_new(session_t *ps, bool ignore_damage)
 	// First need to imitate the depth test on CPU
 	// to decide whether to pass the window to the rendering pipeline
 	if(bkend_use_glx(ps)) {
-		layout_manager_mark_obscured_layers(ps->layout_manager, &reg_paint);
+		// TODO:Kirill - best way is to pass only the damaged region,
+		// now it causes shadow artifacts, so pass the screen_reg
+		layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
 	}
 	for(unsigned int i = 0; i < layout_manager_layout(ps->layout_manager, 0)->len; i++)
 	{

--- a/src/backend/gl/shaders.c
+++ b/src/backend/gl/shaders.c
@@ -68,7 +68,7 @@ const char masking_glsl[] = GLSL(330,
 		vec2 maskcoord = texcoord - mask_offset;
 		vec4 mask = texture2D(mask_tex, maskcoord / mask_size);
 		if (mask_corner_radius != 0) {
-			vec2 inner_size = mask_size - vec2(mask_corner_radius) * 2.0f;
+			vec2 inner_size = mask_size - vec2(mask_corner_radius) * 2.0f - 1;
 			float dist = mask_rectangle_sdf(maskcoord - mask_size / 2.0f,
 			    inner_size / 2.0f) - mask_corner_radius;
 			if (dist > 0.0f) {
@@ -123,7 +123,7 @@ const char win_shader_glsl[] = GLSL(330,
 		vec4 rim_color = mix(c, border_color, clamp(border_width, 0.0f, 1.0f));
 
 		vec2 outer_size = vec2(textureSize(tex, 0));
-		vec2 inner_size = outer_size - vec2(corner_radius) * 2.0f;
+		vec2 inner_size = outer_size - vec2(corner_radius) * 2.0f - 1;
 		float rect_distance = rectangle_sdf(texcoord - outer_size / 2.0f,
 		    inner_size / 2.0f) - corner_radius;
 		if (rect_distance > 0.0f) {

--- a/src/win.c
+++ b/src/win.c
@@ -2918,8 +2918,7 @@ void wins_update_shadow_states(session_t *ps, struct managed_win *old_active_win
 
 	// TODO:Kirill - maybe use only root_damaged(ps)
 	// need transfer this call somewhere
-	if(ps->o.backend == BKEND_XRENDER)
-		force_repaint(ps);
+	force_repaint(ps);
 }
 
 /**


### PR DESCRIPTION
It is a temp fix for shadow render artifacts. 

The problem is caused by the:
1) "layer->to_paint" check. The fix includes passing the screen region instead of the damaged region "reg_paint". The next step is to find out why "reg_paint" makes a complete mess and causes shadow glitches.
2) region to update calculation on active window switch. The fix includes calling "force_repaint" on active window switch in case of "shadow_active=true".

Also this patch makes rounded corners better for glx
