### PR TITLE
Fix fade and animation (astra20+ci2)

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -455,15 +455,14 @@ void paint_all_new(session_t *ps, struct managed_win *bottom, bool ignore_damage
 	//
 	// First need to imitate the depth test on CPU
 	// to decide whether to pass the window to the rendering pipeline
-	if(bkend_use_glx(ps)) { // High CPU usage with xrender
-		// TODO:Kirill - best way is to pass only the damaged region,
-		// now it causes shadow artifacts, so pass the screen_reg
-		layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
-	}
+	//
+	// TODO:Kirill best way is to pass only the damaged region,
+	// now it causes shadow artifacts, so pass the screen_reg
+	layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
 	for (auto w = bottom; w; w = w->prev_trans)
 	{
 		// Process obscured windows
-		if(!w->to_paint) { continue; }
+		if(w->is_obscured) { continue; }
 
 		pixman_region32_subtract(&reg_visible, &ps->screen_reg, w->reg_ignore);
 		assert(!(w->flags & WIN_FLAGS_IMAGE_ERROR));

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -461,11 +461,10 @@ void paint_all_new(session_t *ps, bool ignore_damage)
 		// now it causes shadow artifacts, so pass the screen_reg
 		layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
 	}
-	for(unsigned int i = 0; i < layout_manager_layout(ps->layout_manager, 0)->len; i++)
+	for (auto w = bottom; w; w = w->prev_trans)
 	{
-		auto curr_layer = layout_manager_layout(ps->layout_manager, 0)->layers[i];
-		struct managed_win *w = curr_layer.win;
-		if(!curr_layer.to_paint) { continue; }
+		// Process obscured windows
+		if(!w->to_paint) { continue; }
 
 		pixman_region32_subtract(&reg_visible, &ps->screen_reg, w->reg_ignore);
 		assert(!(w->flags & WIN_FLAGS_IMAGE_ERROR));

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -455,10 +455,11 @@ void paint_all_new(session_t *ps, struct managed_win *bottom, bool ignore_damage
 	//
 	// First need to imitate the depth test on CPU
 	// to decide whether to pass the window to the rendering pipeline
-	
-	// TODO:Kirill - best way is to pass only the damaged region,
-	// now it causes shadow artifacts, so pass the screen_reg
-	layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
+	if(bkend_use_glx(ps)) { // High CPU usage with xrender
+		// TODO:Kirill - best way is to pass only the damaged region,
+		// now it causes shadow artifacts, so pass the screen_reg
+		layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
+	}
 	for (auto w = bottom; w; w = w->prev_trans)
 	{
 		// Process obscured windows

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -323,11 +323,10 @@ draw_win_to_back_buffer(session_t *ps, struct managed_win *w, coord_t window_coo
 }
 
 /// paint all windows
-void paint_all_new(session_t *ps, bool ignore_damage) 
+void paint_all_new(session_t *ps, struct managed_win *bottom, bool ignore_damage) 
 {
 	struct timespec now = get_time_timespec();
 	auto paint_all_start_us = (uint64_t)now.tv_sec * 1000000UL + (uint64_t)now.tv_nsec / 1000;
-	struct managed_win* bottom = layout_manager_layout(ps->layout_manager, 0)->layers[0].win;
 
 	if (ps->backend_data->ops->device_status &&
 	    ps->backend_data->ops->device_status(ps->backend_data) != DEVICE_STATUS_NORMAL) {
@@ -456,11 +455,10 @@ void paint_all_new(session_t *ps, bool ignore_damage)
 	//
 	// First need to imitate the depth test on CPU
 	// to decide whether to pass the window to the rendering pipeline
-	if(bkend_use_glx(ps)) {
-		// TODO:Kirill - best way is to pass only the damaged region,
-		// now it causes shadow artifacts, so pass the screen_reg
-		layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
-	}
+	
+	// TODO:Kirill - best way is to pass only the damaged region,
+	// now it causes shadow artifacts, so pass the screen_reg
+	layout_manager_mark_obscured_layers(ps->layout_manager, &ps->screen_reg);
 	for (auto w = bottom; w; w = w->prev_trans)
 	{
 		// Process obscured windows

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -425,5 +425,5 @@ struct backend_operations {
 
 extern struct backend_operations *backend_list[];
 
-void paint_all_new(session_t *ps, bool ignore_damage)
+void paint_all_new(session_t *ps, struct managed_win *bottom, bool ignore_damage)
     attr_nonnull(1);

--- a/src/picom.c
+++ b/src/picom.c
@@ -744,7 +744,7 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 	//             process fading or animation for it.
 	win_stack_foreach_managed_safe(w, &ps->window_stack) {
 		const winmode_t mode_old = w->mode;
-		const bool was_painted = w->to_paint;
+		const bool was_painted = w->to_paint && !w->is_obscured;
 		const double opacity_old = w->opacity;
 
 		// IMPORTANT: These window animation steps must happen before any other
@@ -995,7 +995,7 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 		__label__ skip_window;
 		bool to_paint = true;
 		// w->to_paint remembers whether this window is painted last time
-		const bool was_painted = w->to_paint;
+		const bool was_painted = w->to_paint && !w->is_obscured;
 
 		// Destroy reg_ignore if some window above us invalidated it
 		if (!reg_ignore_valid) {

--- a/src/picom.c
+++ b/src/picom.c
@@ -1007,11 +1007,15 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 		// Give up if it's not damaged or invisible, or it's unmapped and its
 		// pixmap is gone (for example due to a ConfigureNotify), or when it's
 		// excluded
-		if (w->state == WSTATE_UNMAPPED ||
-		    unlikely(w->base.id == ps->debug_window ||
-		             w->client_win == ps->debug_window)) {
+		if (w->state == WSTATE_UNMAPPED) {
 			to_paint = false;
-		} else if (!w->ever_damaged && w->state != WSTATE_UNMAPPING &&
+		} 
+		else if (unlikely(ps->debug_window != XCB_NONE) &&
+		        (w->base.id == ps->debug_window ||
+		        w->client_win == ps->debug_window)) {
+				to_paint = false;
+		}
+		else if (!w->ever_damaged && w->state != WSTATE_UNMAPPING &&
 		           w->state != WSTATE_DESTROYING) {
 			// Unmapping clears w->ever_damaged, but the fact that the window
 			// is fading out means it must have been damaged when it was still
@@ -1021,13 +1025,15 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 			          "not received any damages",
 			          w->base.id, w->name);
 			to_paint = false;
-		} else if (unlikely(w->g.x + w->g.width < 1 || w->g.y + w->g.height < 1 ||
+		} 
+		else if (unlikely(w->g.x + w->g.width < 1 || w->g.y + w->g.height < 1 ||
 		                    w->g.x >= ps->root_width || w->g.y >= ps->root_height)) {
 			log_trace("Window %#010x (%s) will not be painted because it is "
 			          "positioned outside of the screen",
 			          w->base.id, w->name);
 			to_paint = false;
-		} else if (unlikely((double)w->opacity * MAX_ALPHA < 1 && !w->blur_background)) {
+		} 
+		else if (unlikely((double)w->opacity * MAX_ALPHA < 1 && !w->blur_background)) {
 			/* TODO(yshui) for consistency, even a window has 0 opacity, we
 			 * still probably need to blur its background, so to_paint
 			 * shouldn't be false for them. */
@@ -1035,12 +1041,14 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 			          "0 opacity",
 			          w->base.id, w->name);
 			to_paint = false;
-		} else if (w->paint_excluded) {
+		} 
+		else if (w->paint_excluded) {
 			log_trace("Window %#010x (%s) will not be painted because it is "
 			          "excluded from painting",
 			          w->base.id, w->name);
 			to_paint = false;
-		} else if (unlikely((w->flags & WIN_FLAGS_IMAGE_ERROR) != 0)) {
+		} 
+		else if (unlikely((w->flags & WIN_FLAGS_IMAGE_ERROR) != 0)) {
 			log_trace("Window %#010x (%s) will not be painted because it has "
 			          "image errors",
 			          w->base.id, w->name);

--- a/src/picom.c
+++ b/src/picom.c
@@ -1054,6 +1054,9 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 			          w->base.id, w->name);
 			to_paint = false;
 		}
+		else if(w->is_obscured) {
+			to_paint = false;
+		}
 		// log_trace("%s %d %d %d", w->name, to_paint, w->opacity,
 		// w->paint_excluded);
 

--- a/src/picom.c
+++ b/src/picom.c
@@ -744,7 +744,7 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 	//             process fading or animation for it.
 	win_stack_foreach_managed_safe(w, &ps->window_stack) {
 		const winmode_t mode_old = w->mode;
-		const bool was_painted = w->to_paint && !w->is_obscured;
+		const bool was_painted = w->to_paint;
 		const double opacity_old = w->opacity;
 
 		// IMPORTANT: These window animation steps must happen before any other
@@ -995,7 +995,7 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 		__label__ skip_window;
 		bool to_paint = true;
 		// w->to_paint remembers whether this window is painted last time
-		const bool was_painted = w->to_paint && !w->is_obscured;
+		const bool was_painted = w->to_paint;
 
 		// Destroy reg_ignore if some window above us invalidated it
 		if (!reg_ignore_valid) {
@@ -1052,9 +1052,6 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation) {
 			log_trace("Window %#010x (%s) will not be painted because it has "
 			          "image errors",
 			          w->base.id, w->name);
-			to_paint = false;
-		}
-		else if(w->is_obscured) {
 			to_paint = false;
 		}
 		// log_trace("%s %d %d %d", w->name, to_paint, w->opacity,

--- a/src/picom.c
+++ b/src/picom.c
@@ -1789,7 +1789,8 @@ static void draw_callback_impl(EV_P_ session_t *ps, int revents attr_unused) {
 	}
 
 	// If the screen is unredirected, free all_damage to stop painting
-	if (ps->redirected && ps->o.stoppaint_force != ON) {
+	if (ps->redirected && ps->o.stoppaint_force != ON) 
+	{
 		static int paint = 0;
 
 		log_trace("Render start, frame %d", paint);
@@ -1798,7 +1799,7 @@ static void draw_callback_impl(EV_P_ session_t *ps, int revents attr_unused) {
 			layout_manager_append_layout(ps->layout_manager, &ps->window_stack, ps->root_image_generation,
 			    						(struct geometry){.width = ps->root_width, .height = ps->root_height});
 
-			paint_all_new(ps, bkend_use_xrender(ps) && ps->active_win == ps->switcher_win);
+			paint_all_new(ps, bottom, bkend_use_xrender(ps) && ps->active_win == ps->switcher_win);
 		} 
 		else {
 			paint_all(ps, bottom, false);

--- a/src/renderer/layout.c
+++ b/src/renderer/layout.c
@@ -200,6 +200,7 @@ void layout_manager_mark_obscured_layers(struct layout_manager *lm, region_t *re
 		pixman_region32_intersect(&reg_bound_curr, &reg_bound_curr, &lm->scratch_region);
 		if(!pixman_region32_not_empty(&reg_bound_curr)) {
 			curr_layer->to_paint = false;
+			curr_layer->win->to_paint = false;
 		}
 
 		if(curr_layer->is_opaque) {

--- a/src/renderer/layout.c
+++ b/src/renderer/layout.c
@@ -197,10 +197,14 @@ void layout_manager_mark_obscured_layers(struct layout_manager *lm, region_t *re
 		auto curr_layer = &layout_manager_layout(lm, 0)->layers[i];
 		auto reg_bound_curr = win_get_bounding_shape_global_by_val(curr_layer->win);
 
+		curr_layer->win->is_obscured = false;
+
 		pixman_region32_intersect(&reg_bound_curr, &reg_bound_curr, &lm->scratch_region);
 		if(!pixman_region32_not_empty(&reg_bound_curr)) {
 			curr_layer->to_paint = false;
-			curr_layer->win->to_paint = false;
+			// TODO:Kirill dont change window states 
+			// after full switch to layout system
+			curr_layer->win->is_obscured = true;
 		}
 
 		if(curr_layer->is_opaque) {

--- a/src/win.c
+++ b/src/win.c
@@ -943,6 +943,7 @@ bool win_should_change_shadow_state(session_t *ps, struct managed_win *w, bool f
 {
 	if(!w) return false;
 	if(!ps->o.shadow_active || !ps->o.wintype_option[w->window_type].shadow_active) return false;
+	if(w->state == WSTATE_UNMAPPING || w->state == WSTATE_DESTROYING) return false;
 
 	if(focused && w->focused) return true;
 	else if(!focused && !w->focused) return true;
@@ -2226,14 +2227,16 @@ struct shadow_geometry win_get_shadow_geometry(session_t *ps, struct managed_win
 
 void win_update_shadow_geometry(session_t *ps, struct managed_win *w)
 {
-	struct shadow_geometry geometry = win_get_shadow_geometry(ps, w);
+	if(w->state != WSTATE_UNMAPPING && w->state != WSTATE_DESTROYING) {
+		w->shadow_g = win_get_shadow_geometry(ps, w);
+	}
 
-	w->shadow_dx = geometry.offset_x;
-	w->shadow_dy = geometry.offset_y;
+	w->shadow_dx = w->shadow_g.offset_x;
+	w->shadow_dy = w->shadow_g.offset_y;
 	w->widthb = w->g.width + w->g.border_width * 2;
 	w->heightb = w->g.height + w->g.border_width * 2;
-	w->shadow_width = w->widthb + geometry.radius * 2;
-	w->shadow_height = w->heightb + geometry.radius * 2;
+	w->shadow_width = w->widthb + w->shadow_g.radius * 2;
+	w->shadow_height = w->heightb + w->shadow_g.radius * 2;
 }
 
 /**
@@ -2247,6 +2250,7 @@ void win_on_win_size_change(session_t *ps, struct managed_win *w) {
 
 	// Invalidate the shadow we built
 	win_update_shadow_geometry(ps, w);
+
 	win_set_flags(w, WIN_FLAGS_IMAGES_STALE);
 	win_release_mask(ps->backend_data, w);
 	ps->pending_updates = true;
@@ -2535,6 +2539,10 @@ struct win *fill_win(session_t *ps, struct win *w) {
 	    .shadow_width = 0,
 	    .shadow_height = 0,
 	    .damage = XCB_NONE,
+
+		.shadow_g.offset_x = 0,
+		.shadow_g.offset_y = 0,
+		.shadow_g.radius = 0,
 
 		.shadow_color.red = NAN,
 		.shadow_color.green = NAN,

--- a/src/win.c
+++ b/src/win.c
@@ -2505,6 +2505,7 @@ struct win *fill_win(session_t *ps, struct win *w) {
 	    // The following ones are updated during paint or paint preprocess
 	    .shadow_opacity = 0.0,
 	    .to_paint = false,
+		.is_obscured = false,
 	    .frame_opacity = 1.0,
 	    .dim = false,
 	    .invert_color = false,

--- a/src/win.h
+++ b/src/win.h
@@ -185,6 +185,8 @@ struct managed_win {
 	bool rounded_corners;
 	/// Whether this window is to be painted.
 	bool to_paint;
+	/// Whether this window is overlapped.
+	bool is_obscured;
 	/// Whether the window is painting excluded.
 	bool paint_excluded;
 	/// Whether the window is unredirect-if-possible excluded.

--- a/src/win.h
+++ b/src/win.h
@@ -286,6 +286,8 @@ struct managed_win {
 	margin_t frame_extents;
 
 	// Shadow-related members
+	// Window base shadow geometry data
+	struct shadow_geometry shadow_g;
 	/// Whether a window has shadow. Calculated.
 	bool shadow;
 	/// Override value of window shadow state. Set by D-Bus method calls.


### PR DESCRIPTION
Правки:

1) исправлена проблема с нерабочим fade-out и **unmap** анимацией (анимация на закрытие/скрытие окна зависит от того, работает ли **fade-out**);
2) система layout пока используется только для обозначения перекрытых окон;
3) геометрия тени окна не запрашивается в состояниях **WSTATE_UNMAPPING** и **WSTATE_DESTROYING** - применяются прежние параметры;
4) отрисовка перекрытых окон пропускается для xrender и glx;

Нужно исправить/добавить:

1) полностью перейти на систему layout;
2) не выполнять детальный paint_preprocess для перекрытых окон и при этом сохранить оперативный рендер ранее скрытых окон;
3) исправить резкое удаление тени при **fade-out** на **legacy glx**;
